### PR TITLE
Add C3D.Extensions.Aspire.OutputWatcher and C3D.Extensions.Aspire.WaitForOutput

### DIFF
--- a/C3D.Extensions.Aspire.IISExpress.sln
+++ b/C3D.Extensions.Aspire.IISExpress.sln
@@ -26,9 +26,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B02941E8-EB9
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{A0E19FE4-77FC-4D32-B29C-D31909D2DBC2}"
-	ProjectSection(SolutionItems) = preProject
-		samples\Directory.Build.props = samples\Directory.Build.props
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "C3D.Extensions.Aspire.IISExpress", "src\C3D\Extensions\Aspire\IISExpress\C3D.Extensions.Aspire.IISExpress.csproj", "{6156F6B9-89C5-445D-AD9C-F71C80C4A330}"
 EndProject
@@ -53,9 +50,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyWebApplication", "samples\Legacy\LegacyWebApplication\LegacyWebApplication.csproj", "{85C0E2EE-A1DB-40D8-BE13-44B740101986}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SWA", "SWA", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
-	ProjectSection(SolutionItems) = preProject
-		samples\SWA\version.json = samples\SWA\version.json
-	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SWAFramework", "samples\SWA\SWAFramework\SWAFramework.csproj", "{08170CE6-B907-4266-A91D-4176905720A3}"
 EndProject
@@ -68,6 +62,22 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C3D.Extensions.Aspire.VisualStudioDebug", "src\C3D\Extensions\Aspire\VisualStudioDebug\C3D.Extensions.Aspire.VisualStudioDebug.csproj", "{2FC6474B-6F18-4BF2-BB66-53B8C7C2B84E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C3D.Extensions.VisualStudioDebug", "src\C3D\Extensions\VisualStudioDebug\C3D.Extensions.VisualStudioDebug.csproj", "{EC5EAC82-FCAA-4134-B101-DDECC71D9AF5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C3D.Extensions.Aspire.OutputWatcher", "src\C3D\Extensions\Aspire\OutputWatcher\C3D.Extensions.Aspire.OutputWatcher.csproj", "{C2C95C50-D091-D037-A5BD-1C6831ED1142}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "C3D.Extensions.HostingExtensions.Shared", "src\C3D\Extensions\HostingExtensions.Shared\C3D.Extensions.HostingExtensions.Shared.shproj", "{DB4C7646-4434-4511-9E15-4019FEF2D975}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C3D.Extensions.Aspire.WaitForOutput", "src\C3D\Extensions\Aspire\WaitForOutput\C3D.Extensions.Aspire.WaitForOutput.csproj", "{07E3ECEB-E1AC-4566-869E-3523473FD45E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WaitForConsole", "WaitForConsole", "{3CE52242-69A6-4569-96CB-483D7116522D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireAppHostWaitForConsole", "samples\WaitForOutput\AspireWaitForConsoleOutput.AppHost\AspireAppHostWaitForConsole.csproj", "{6A2453E7-26E2-899F-4A97-1EB4F0CB440C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WaitForConsole.Shared", "samples\WaitForOutput\AspireWaitForConsoleOutput.ServiceDefaults\WaitForConsole.Shared.csproj", "{C65F331E-ABE2-C5E3-2BD6-77E040124C29}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WaitForConsole.ConsoleApp", "samples\WaitForOutput\ConsoleApp\WaitForConsole.ConsoleApp.csproj", "{69B8531B-EDA8-5DB5-6D55-3DF3F8D1310F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WaitForConsole.WebApp", "samples\WaitForOutput\WebApplication\WaitForConsole.WebApp.csproj", "{111E1366-2322-3E44-36B2-60EDFB12A478}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -131,6 +141,30 @@ Global
 		{EC5EAC82-FCAA-4134-B101-DDECC71D9AF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC5EAC82-FCAA-4134-B101-DDECC71D9AF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC5EAC82-FCAA-4134-B101-DDECC71D9AF5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2C95C50-D091-D037-A5BD-1C6831ED1142}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2C95C50-D091-D037-A5BD-1C6831ED1142}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2C95C50-D091-D037-A5BD-1C6831ED1142}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2C95C50-D091-D037-A5BD-1C6831ED1142}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07E3ECEB-E1AC-4566-869E-3523473FD45E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07E3ECEB-E1AC-4566-869E-3523473FD45E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07E3ECEB-E1AC-4566-869E-3523473FD45E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07E3ECEB-E1AC-4566-869E-3523473FD45E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A2453E7-26E2-899F-4A97-1EB4F0CB440C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A2453E7-26E2-899F-4A97-1EB4F0CB440C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A2453E7-26E2-899F-4A97-1EB4F0CB440C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A2453E7-26E2-899F-4A97-1EB4F0CB440C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C65F331E-ABE2-C5E3-2BD6-77E040124C29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C65F331E-ABE2-C5E3-2BD6-77E040124C29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C65F331E-ABE2-C5E3-2BD6-77E040124C29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C65F331E-ABE2-C5E3-2BD6-77E040124C29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69B8531B-EDA8-5DB5-6D55-3DF3F8D1310F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69B8531B-EDA8-5DB5-6D55-3DF3F8D1310F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69B8531B-EDA8-5DB5-6D55-3DF3F8D1310F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69B8531B-EDA8-5DB5-6D55-3DF3F8D1310F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{111E1366-2322-3E44-36B2-60EDFB12A478}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{111E1366-2322-3E44-36B2-60EDFB12A478}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{111E1366-2322-3E44-36B2-60EDFB12A478}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{111E1366-2322-3E44-36B2-60EDFB12A478}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,8 +188,20 @@ Global
 		{CC2EA056-A6F4-481B-87A5-A41B0158C178} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{2FC6474B-6F18-4BF2-BB66-53B8C7C2B84E} = {B02941E8-EB9F-4AFF-8383-6B231DD01754}
 		{EC5EAC82-FCAA-4134-B101-DDECC71D9AF5} = {B02941E8-EB9F-4AFF-8383-6B231DD01754}
+		{C2C95C50-D091-D037-A5BD-1C6831ED1142} = {B02941E8-EB9F-4AFF-8383-6B231DD01754}
+		{DB4C7646-4434-4511-9E15-4019FEF2D975} = {B02941E8-EB9F-4AFF-8383-6B231DD01754}
+		{07E3ECEB-E1AC-4566-869E-3523473FD45E} = {B02941E8-EB9F-4AFF-8383-6B231DD01754}
+		{3CE52242-69A6-4569-96CB-483D7116522D} = {A0E19FE4-77FC-4D32-B29C-D31909D2DBC2}
+		{6A2453E7-26E2-899F-4A97-1EB4F0CB440C} = {3CE52242-69A6-4569-96CB-483D7116522D}
+		{C65F331E-ABE2-C5E3-2BD6-77E040124C29} = {3CE52242-69A6-4569-96CB-483D7116522D}
+		{69B8531B-EDA8-5DB5-6D55-3DF3F8D1310F} = {3CE52242-69A6-4569-96CB-483D7116522D}
+		{111E1366-2322-3E44-36B2-60EDFB12A478} = {3CE52242-69A6-4569-96CB-483D7116522D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A2C1EF4-C8A0-49A5-8198-0BFBDFE2EE42}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\C3D\Extensions\HostingExtensions.Shared\HostingExtensions.Shared.projitems*{c2c95c50-d091-d037-a5bd-1c6831ed1142}*SharedItemsImports = 5
+		src\C3D\Extensions\HostingExtensions.Shared\HostingExtensions.Shared.projitems*{db4c7646-4434-4511-9e15-4019fef2d975}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ A set of packages to make it easier to work with IIS Express / System.Web projec
 [![NuGet package](https://img.shields.io/nuget/v/C3D.Extensions.Aspire.VisualStudioDebug.svg)](https://nuget.org/packages/C3D.Extensions.Aspire.VisualStudioDebug)
 [![NuGet downloads](https://img.shields.io/nuget/dt/C3D.Extensions.Aspire.VisualStudioDebug.svg)](https://nuget.org/packages/C3D.Extensions.Aspire.VisualStudioDebug)
 
+## [C3D.Extensions.Aspire.OutputWatcher](src/C3D/Extensions/Aspire/OutputWatcher/README.md)
+[![NuGet package](https://img.shields.io/nuget/v/C3D.Extensions.Aspire.OutputWatcher.svg)](https://nuget.org/packages/C3D.Extensions.Aspire.OutputWatcher)
+[![NuGet downloads](https://img.shields.io/nuget/dt/C3D.Extensions.Aspire.OutputWatcher.svg)](https://nuget.org/packages/C3D.Extensions.Aspire.OutputWatcher)
+
+## [C3D.Extensions.Aspire.WaitForOutput](src/C3D/Extensions/Aspire/WaitForOutput/README.md)
+[![NuGet package](https://img.shields.io/nuget/v/C3D.Extensions.Aspire.WaitForOutput.svg)](https://nuget.org/packages/C3D.Extensions.Aspire.WaitForOutput)
+[![NuGet downloads](https://img.shields.io/nuget/dt/C3D.Extensions.Aspire.WaitForOutput.svg)](https://nuget.org/packages/C3D.Extensions.Aspire.WaitForOutput)
+
+
 # Support Packages
 
 ## [C3D.Extensions.VisualStudioDebug](src/C3D/Extensions/VisualStudioDebug/README.md)
@@ -50,3 +59,7 @@ This consists of a Full Framework example app using MVC, with some of the code f
 The Core app is lightweight and only contains YARP, a Session variable route (per the RemoteSession example), OTLP telemetry, and HeathChecks.
 Apire sets up a randomized app key used by both applications, and wires up the Urls for YARP etc.
 Traces show the request span of the core app, the proxy request, and the framework processing.
+
+## WaitForConsole
+This shows how to use the WaitForOutput package to wait for a console app to output a specific message before starting another process.
+It also shows how to monitor for a string using a regex, and use the matched string as an environment variable in the next process.

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/AspireAppHostWaitForConsole.csproj
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/AspireAppHostWaitForConsole.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.1.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>776e4116-e4e3-4b24-afc0-6fd1a8f6760d</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\C3D\Extensions\Aspire\WaitForOutput\C3D.Extensions.Aspire.WaitForOutput.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\ConsoleApp\WaitForConsole.ConsoleApp.csproj" />
+    <ProjectReference Include="..\WebApplication\WaitForConsole.WebApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/Program.cs
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/Program.cs
@@ -1,0 +1,63 @@
+using C3D.Extensions.Aspire.OutputWatcher;
+using Google.Protobuf.WellKnownTypes;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+internal partial class Program
+{
+    private static void Main(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+
+        var sql = builder.AddSqlServer("sql");
+        var sqldb = sql.AddDatabase("sqldb");
+
+        // Example of waiting for a console app to output a specific message
+        // This could be an Executable of some sort - such as Node, Python, etc.
+        // We wait for some pre-requisite to be ready, then we wait for the console app to output a specific message
+        var console = builder.AddProject<Projects.WaitForConsole_ConsoleApp>("consoleapp")
+            .WithReference(sqldb, "sqldb")
+            .WaitFor(sqldb)
+            .WithOutputWatcher(GetMagic(), true, "magic");
+
+        // The GetMagic Regex will capture the magic number from the console app output and store it as a property
+        // The output string will be of the format "{number} is the magic number!"
+        // Once it is detected, we can store it in a ReferenceExpression to be used as an environment variable in the next project
+        ReferenceExpression? magicNumber = null;
+        var magicNumberSubscription = builder.Eventing.Subscribe<OutputMatchedEvent>(console.Resource, (o, c) =>
+        {
+            if (o.Key == "magic")
+            {
+                // Get the magic number from the console app
+                // The regex match group capture is 'magic' and will be stored as a property.
+                var number = int.Parse(o.Properties["magic"].ToString()!);
+                
+                var reb = new ReferenceExpressionBuilder();
+                reb.AppendFormatted($"{number}");
+                magicNumber = reb.Build();
+            }
+
+            return Task.CompletedTask;
+        });
+
+        // webapp won't start until console has output the message "Ready Now..."
+        // Note that 'console' does not have to exit, it just has to output the message
+        builder.AddProject<Projects.WaitForConsole_WebApp>("webapp")
+            .WithReference(sqldb, "sqldb")
+            .WaitFor(sqldb)
+            .WaitForOutput(console, m => m == "Ready Now...")
+            .WithEnvironment(c =>
+            {
+                if (magicNumber is not null)
+                {
+                    c.EnvironmentVariables["MAGIC_NUMBER"] = magicNumber;
+                }
+            });
+
+        builder.Build().Run();
+    }
+
+    [GeneratedRegex("^(?<magic>.*\\d)(?:( is the magic number!))$")]
+    public static partial Regex GetMagic();
+}
+

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/Properties/launchSettings.json
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17135;http://localhost:15251",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21080",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22128"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15251",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19295",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20240"
+      }
+    }
+  }
+}

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/appsettings.Development.json
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/appsettings.json
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.AppHost/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning",
+      "C3D.Extensions.Aspire.OutputWatcher": "Debug"
+    }
+  }
+}

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.ServiceDefaults/Extensions.cs
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.ServiceDefaults/Extensions.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+public static class Extensions
+{
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            // Turn on resilience by default
+            http.AddStandardResilienceHandler();
+
+            // Turn on service discovery by default
+            http.AddServiceDiscovery();
+        });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
+
+        return builder;
+    }
+
+    public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
+                    // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                    //.AddGrpcClientInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        //{
+        //    builder.Services.AddOpenTelemetry()
+        //       .UseAzureMonitor();
+        //}
+
+        return builder;
+    }
+
+    public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/samples/WaitForOutput/AspireWaitForConsoleOutput.ServiceDefaults/WaitForConsole.Shared.csproj
+++ b/samples/WaitForOutput/AspireWaitForConsoleOutput.ServiceDefaults/WaitForConsole.Shared.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/WaitForOutput/ConsoleApp/Program.cs
+++ b/samples/WaitForOutput/ConsoleApp/Program.cs
@@ -1,0 +1,19 @@
+﻿namespace ConsoleApp
+{
+    internal class Program
+    {
+        static async Task Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            Console.WriteLine($"{Random.Shared.Next(100)} is the magic number!");
+            Console.WriteLine("Ready Now...");
+
+            while (true)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                Console.WriteLine("Tick...");
+            }
+        }
+    }
+}

--- a/samples/WaitForOutput/ConsoleApp/WaitForConsole.ConsoleApp.csproj
+++ b/samples/WaitForOutput/ConsoleApp/WaitForConsole.ConsoleApp.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/samples/WaitForOutput/README.md
+++ b/samples/WaitForOutput/README.md
@@ -1,0 +1,6 @@
+# AspireWaitForConsoleOutput
+
+This is a simple utility that waits for a specific string to appear in the console output of a process before
+starting the next process when using Aspire. 
+
+It is useful for integration tests where you want to wait for a specific string to appear in the console output of a process before proceeding.

--- a/samples/WaitForOutput/WebApplication/Program.cs
+++ b/samples/WaitForOutput/WebApplication/Program.cs
@@ -1,0 +1,17 @@
+namespace WebApp;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        builder.AddServiceDefaults();
+        var app = builder.Build();
+        app.MapDefaultEndpoints();
+        var magicNumber = builder.Configuration.GetValue<int?>("MAGIC_NUMBER");
+        var magicString = magicNumber.HasValue ? $"The magic number is {magicNumber}" : "The magic number was not set";
+        app.MapGet("/", () => magicString);
+
+        app.Run();
+    }
+}

--- a/samples/WaitForOutput/WebApplication/Properties/launchSettings.json
+++ b/samples/WaitForOutput/WebApplication/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5274",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7138;http://localhost:5274",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/WaitForOutput/WebApplication/WaitForConsole.WebApp.csproj
+++ b/samples/WaitForOutput/WebApplication/WaitForConsole.WebApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AspireWaitForConsoleOutput.ServiceDefaults\WaitForConsole.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/WaitForOutput/WebApplication/appsettings.Development.json
+++ b/samples/WaitForOutput/WebApplication/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/WaitForOutput/WebApplication/appsettings.json
+++ b/samples/WaitForOutput/WebApplication/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/Annotations/OutputWatcherAnnotation.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/Annotations/OutputWatcherAnnotation.cs
@@ -1,0 +1,24 @@
+﻿namespace C3D.Extensions.Aspire.OutputWatcher.Annotations;
+
+public class OutputWatcherAnnotation : OutputWatcherAnnotationBase
+{
+
+    private readonly Func<string, bool> predicate;
+    private readonly string predicateName;
+
+    public OutputWatcherAnnotation(
+        Func<string, bool> predicate,
+        bool isSecret,
+        string? key = null, 
+        string? predicateName = null)
+        : base(isSecret,key)
+    {
+        this.predicate = predicate;
+        this.predicateName = predicateName ?? string.Empty;
+        ;
+    }
+
+    public override string PredicateName => predicateName;
+
+    public override bool IsMatch(string message) => predicate(message);
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/Annotations/OutputWatcherAnnotationBase.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/Annotations/OutputWatcherAnnotationBase.cs
@@ -1,0 +1,54 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using System.Diagnostics;
+
+namespace C3D.Extensions.Aspire.OutputWatcher.Annotations;
+
+[DebuggerDisplay("{Key} {Predicate}")]
+public abstract class OutputWatcherAnnotationBase : IResourceAnnotation
+{
+    public bool IsSecret { get; }
+    public string Key { get; }
+    public abstract string PredicateName { get; }
+
+    protected OutputWatcherAnnotationBase(bool isSecret, string? key = null)
+    {
+        IsSecret = isSecret;
+        Key = key ?? $"ow-{Guid.NewGuid()}";
+    }
+
+    protected Dictionary<string, object> properties = new();
+
+    public IReadOnlyDictionary<string, object> Properties => properties.AsReadOnly();
+
+    public abstract bool IsMatch(string message);
+
+
+    #region "WellKnown Properties"
+    public DateTimeOffset? TimeStamp
+    {
+        get => properties.TryGetValue(nameof(TimeStamp), out var value) ? value as DateTime? : null;
+        internal set
+        {
+            if (value is null)
+            {
+                properties.Remove(nameof(TimeStamp));
+                return;
+            }
+            properties[nameof(TimeStamp)] = value;
+        }
+    }
+    public string? Message
+    {
+        get => properties.TryGetValue(nameof(Message), out var value) ? value.ToString() : null;
+        internal set
+        {
+            if (value is null)
+            {
+                properties.Remove(nameof(Message));
+                return;
+            }
+            properties[nameof(Message)] = value;
+        }
+    }
+    #endregion
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/Annotations/OutputWatcherRegExAnnotation.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/Annotations/OutputWatcherRegExAnnotation.cs
@@ -1,0 +1,39 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using System.Text.RegularExpressions;
+
+namespace C3D.Extensions.Aspire.OutputWatcher.Annotations;
+
+public class OutputWatcherRegExAnnotation : OutputWatcherAnnotationBase, IValueProvider
+{
+    private readonly Regex matcher;
+
+    public OutputWatcherRegExAnnotation(
+        Regex matcher,
+        bool isSecret,
+        string? key = null)
+        : base(isSecret, key)
+    {
+        this.matcher = matcher;
+    }
+
+    public override string PredicateName => matcher.ToString();
+
+    public Func<OutputWatcherRegExAnnotation, ValueTask<string?>> ValueFunc { get; set; } = 
+        static async (annotation) =>
+            await Task.FromResult(annotation.properties["Match"]?.ToString());
+
+    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default) => await ValueFunc(this);
+
+    public override bool IsMatch(string message)
+    {
+        if (matcher.IsMatch(message))
+        {
+            properties["Match"] = matcher.Match(message).Value;
+            foreach (var groupName in matcher.GetGroupNames())
+            {
+                properties[groupName] = matcher.Match(message).Groups[groupName].Value;
+            }
+        }
+        return matcher.IsMatch(message);
+    }
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/C3D.Extensions.Aspire.OutputWatcher.csproj
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/C3D.Extensions.Aspire.OutputWatcher.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="9.1.0" />
+  </ItemGroup>
+
+  <Import Project="..\..\HostingExtensions.Shared\HostingExtensions.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/C3D/Extensions/Aspire/OutputWatcher/Extensions/OutputWatcherExtensions.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/Extensions/OutputWatcherExtensions.cs
@@ -1,0 +1,80 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using C3D.Extensions.Aspire.OutputWatcher;
+using C3D.Extensions.Aspire.OutputWatcher.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.RegularExpressions;
+
+namespace Aspire.Hosting;
+
+public static class OutputWatcherExtensions
+{
+    public static IServiceCollection AddResourceOutputWatcher(this IServiceCollection services) =>
+        services.InsertHostedService<ResourceOutputWatcherService>();
+
+    public static OutputWatcherBuilder<TResource, OutputWatcherAnnotation> WithOutputWatcher<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        string match,
+        StringComparison comparer = StringComparison.InvariantCulture,
+        bool isSecret = false,
+        string? key = null)
+        where TResource : IResource => resourceBuilder.WithOutputWatcher(
+            message => message.Equals(match, comparer), isSecret, key, match);
+
+    internal static OutputWatcherBuilder<TResource, TAnnotation> WithOutputWatcher<TResource, TAnnotation>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        Func<string?, TAnnotation> annotationFactory,
+        string? key = null)
+        where TResource : IResource
+        where TAnnotation : OutputWatcherAnnotationBase
+    {
+        resourceBuilder.ApplicationBuilder.Services.AddResourceOutputWatcher();
+
+        var annotation = annotationFactory(key);
+        resourceBuilder.WithAnnotation(annotation);
+        return new(resourceBuilder, annotation);
+    }
+
+    public static OutputWatcherBuilder<TResource, OutputWatcherRegExAnnotation> WithOutputWatcher<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        Regex matcher,
+        bool isSecret = false,
+        string? key = null)
+        where TResource : IResource => resourceBuilder.WithOutputWatcher(
+            k => new OutputWatcherRegExAnnotation(matcher, isSecret, k), key);
+
+    public static OutputWatcherBuilder<TResource, OutputWatcherAnnotation> WithOutputWatcher<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        Func<string, bool> predicate,
+        bool isSecret = false,
+        string? key = null,
+        string? predicateDisplayName = null)
+        where TResource : IResource
+            => resourceBuilder.WithOutputWatcher(
+                k => new OutputWatcherAnnotation(predicate, isSecret, k, predicateDisplayName), key);
+
+    public sealed class OutputWatcherBuilder<TResource, TWatcherAnnotation> : IResourceBuilder<TResource>
+        where TResource : IResource
+        where TWatcherAnnotation : OutputWatcherAnnotationBase
+    {
+        internal OutputWatcherBuilder(IResourceBuilder<TResource> inner, TWatcherAnnotation annotation)
+        {
+            ResourceBuilder = inner;
+            Annotation = annotation;
+        }
+
+        public IDistributedApplicationBuilder ApplicationBuilder => ResourceBuilder.ApplicationBuilder;
+
+        public TResource Resource => ResourceBuilder.Resource;
+
+        public TWatcherAnnotation Annotation { get; }
+
+        public string Key => Annotation.Key;
+
+        public IResourceBuilder<TResource> ResourceBuilder { get; }
+
+        public IResourceBuilder<TResource> WithAnnotation<TAnnotation>(TAnnotation annotation,
+            ResourceAnnotationMutationBehavior behavior = ResourceAnnotationMutationBehavior.Append)
+            where TAnnotation : IResourceAnnotation
+                => ResourceBuilder.WithAnnotation(annotation, behavior);
+    }
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/OutputMatchedEvent.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/OutputMatchedEvent.cs
@@ -1,0 +1,24 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+
+namespace C3D.Extensions.Aspire.OutputWatcher;
+
+public class OutputMatchedEvent : IDistributedApplicationResourceEvent
+{
+    public OutputMatchedEvent(IServiceProvider serviceProvider, IResource resource, string key, string message, IReadOnlyDictionary<string, object> properties)
+    {
+        Resource = resource;
+        ServiceProvider = serviceProvider;
+        Key = key;
+        Message = message;
+        Properties = properties;
+    }
+
+    public IResource Resource { get; }
+    public IServiceProvider ServiceProvider { get; }
+
+    public string Key { get; }
+    public string Message { get; }
+
+    public IReadOnlyDictionary<string, object> Properties { get; }
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/OutputWatcherAnnotationValueProvider.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/OutputWatcherAnnotationValueProvider.cs
@@ -1,0 +1,32 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using C3D.Extensions.Aspire.OutputWatcher.Annotations;
+
+namespace C3D.Extensions.Aspire.OutputWatcher;
+
+public class OutputWatcherAnnotationValueProvider<TBase> : IValueProvider, IManifestExpressionProvider, IValueWithReferences
+    where TBase : OutputWatcherAnnotationBase
+{
+    private Func<object?, ValueTask<string?>> formatter;
+
+    public OutputWatcherAnnotationValueProvider(IResource resource, TBase annotation,
+        string property, Func<object?, ValueTask<string?>>? formatter)
+    {
+        Resource = resource;
+        Annotation = annotation;
+        Property = property;
+        this.formatter = formatter ?? (o => ValueTask.FromResult(o?.ToString()));
+    }
+
+
+    public TBase Annotation { get; }
+    public string Property { get; }
+
+    public string ValueExpression => Property;
+
+    public IEnumerable<object> References => [Annotation, Resource];
+
+    public IResource Resource { get; }
+
+    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default) =>
+        await formatter(Annotation.Properties[Property]);
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/README.md
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/README.md
@@ -3,4 +3,6 @@
 A service that can be injected to monitor the output of a resource for a specific string, regex, or other predicate.
 Upon detection, the eventing system will raise the `OutputMatchedEvent` event and the `OutputWatcherAnnotation` will store the last match.
 
+Extension methods are provided to make it easy to get the matched string as a ReferenceExpression.
+
 This can be used as the basis for other extensions, such as NodeJS debugging by watching for the `Debugger listening on ws://` message, or a healthcheck waiting for a specific string from a console application that perhaps does not terminate.

--- a/src/C3D/Extensions/Aspire/OutputWatcher/README.md
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/README.md
@@ -1,0 +1,6 @@
+# C3D.Extensions.Aspire.OutputWatcher
+
+A service that can be injected to monitor the output of a resource for a specific string, regex, or other predicate.
+Upon detection, the eventing system will raise the `OutputMatchedEvent` event and the `OutputWatcherAnnotation` will store the last match.
+
+This can be used as the basis for other extensions, such as NodeJS debugging by watching for the `Debugger listening on ws://` message, or a healthcheck waiting for a specific string from a console application that perhaps does not terminate.

--- a/src/C3D/Extensions/Aspire/OutputWatcher/ResourceOutputWatcherService.cs
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/ResourceOutputWatcherService.cs
@@ -1,0 +1,117 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+using C3D.Extensions.Aspire.OutputWatcher.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+
+namespace C3D.Extensions.Aspire.OutputWatcher;
+
+public class ResourceOutputWatcherService : BackgroundService
+{
+    private readonly ILogger<ResourceOutputWatcherService> logger;
+    private readonly ResourceLoggerService resourceLoggerService;
+    private readonly IDistributedApplicationEventing distributedApplicationEventing;
+    private readonly DistributedApplicationModel model;
+    private readonly IServiceProvider serviceProvider;
+    private readonly TimeProvider timeProvider;
+
+    public ResourceOutputWatcherService(
+        ILogger<ResourceOutputWatcherService> logger,
+        ResourceLoggerService resourceLoggerService,
+        DistributedApplicationModel model,
+        IDistributedApplicationEventing distributedApplicationEventing,
+        IServiceProvider serviceProvider,
+        TimeProvider? timeProvider = null)
+    {
+        this.logger = logger;
+        this.resourceLoggerService = resourceLoggerService;
+        this.distributedApplicationEventing = distributedApplicationEventing;
+        this.model = model;
+        this.serviceProvider = serviceProvider;
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+        logger.LogInformation("ConsoleOutputWatcherService created.");
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("ConsoleOutputWatcherService started.");
+        var tasks = model.Resources.Where(r => r.HasAnnotationOfType<OutputWatcherAnnotationBase>())
+            .Select(r => WatchResourceAsync(r, stoppingToken))
+            .ToArray();
+        await Task.WhenAll(tasks);
+        logger.LogInformation("ConsoleOutputWatcherService stopped.");
+    }
+
+    public const string ConsoleLogsTimestampFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
+    private readonly static int ConsoleLogsTimestampFormatLength = ConsoleLogsTimestampFormat.Length;
+    private readonly static int MessageStartOffset = ConsoleLogsTimestampFormatLength+1;
+
+    private async Task WatchResourceAsync(IResource resource, CancellationToken stoppingToken)
+    {
+        
+
+        logger.LogInformation("Waiting for {Resource} output", resource.Name);
+        if (resource.TryGetAnnotationsOfType<OutputWatcherAnnotationBase>(out var annotations))
+        {
+            bool isSecret = annotations.Any(a => a.IsSecret);
+            await foreach (var output in resourceLoggerService.WatchAsync(resource).WithCancellation(stoppingToken))
+            {
+                foreach (var line in output)
+                {
+                    if (isSecret)
+                    {
+                        logger.LogDebug("Received {Resource} output: {LineNumber} <Redacted>", resource.Name, line.LineNumber);
+                    }
+                    else
+                    {
+                        if (line.IsErrorMessage)
+                        {
+                            logger.LogWarning("Received {Resource} output: {LineNumber} {Content}", resource.Name, line.LineNumber, line.Content);
+                        }
+                        else
+                        {
+                            logger.LogDebug("Received {Resource} output: {LineNumber} {Content}", resource.Name, line.LineNumber, line.Content);
+                        }
+                    }
+                    try
+                    {
+                        var message = DateTimeOffset.TryParseExact(
+                            line.Content.AsSpan()[..ConsoleLogsTimestampFormatLength], ConsoleLogsTimestampFormat,
+                            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var timeStamp)
+                            ? line.Content[MessageStartOffset..] : line.Content;
+
+                        foreach (var annotation in annotations)
+                        {
+                            await ProcessLineAsync(resource, annotation, timeStamp, message, stoppingToken);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError(e, "Failed to process {Resource} output {Message}", resource.Name, e.Message);
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task ProcessLineAsync(IResource resource, OutputWatcherAnnotationBase annotation,
+            DateTimeOffset? timeStamp, string line, CancellationToken stoppingToken)
+    {
+        if (annotation.IsMatch(line))
+        {
+            logger.LogInformation("{Resource} output matched {predicate} {key}.", resource.Name, annotation.PredicateName, annotation.Key);
+            annotation.Message = annotation.IsSecret ? "<Redacted>" : line;
+            annotation.TimeStamp = timeStamp ?? timeProvider.GetUtcNow();
+
+            await distributedApplicationEventing.PublishAsync(ActivatorUtilities.CreateInstance<OutputMatchedEvent>(
+                serviceProvider,
+                resource,
+                annotation.Key,
+                annotation.Message,
+                annotation.Properties
+                ), stoppingToken);
+        }
+    }
+}

--- a/src/C3D/Extensions/Aspire/OutputWatcher/version.json
+++ b/src/C3D/Extensions/Aspire/OutputWatcher/version.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.3.37/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.1",
+  "pathFilters": [
+    ".",
+    "../Directory.Build.props",
+    "../Directory.Build.targets"
+  ],
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$", // we release out of main
+    "^refs/heads/rel/v\\d+\\.\\d+" // we also release tags starting with rel/N.N
+  ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
+  "buildNumberOffset": 0
+}

--- a/src/C3D/Extensions/Aspire/WaitForOutput/C3D.Extensions.Aspire.WaitForOutput.csproj
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/C3D.Extensions.Aspire.WaitForOutput.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OutputWatcher\C3D.Extensions.Aspire.OutputWatcher.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/HealthChecksExtensions.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/HealthChecksExtensions.cs
@@ -1,0 +1,51 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aspire.Hosting;
+
+public static class HealthChecksExtensions
+{
+    public static ResourceHealthChecksBuilder<TResource> WithLocalHealthChecks<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder)
+        where TResource : IResource
+    {
+        return new(resourceBuilder, resourceBuilder.ApplicationBuilder.Services.AddHealthChecks());
+
+    }
+
+    public class ResourceHealthChecksBuilder<TResource> : IResourceBuilder<TResource>, IHealthChecksBuilder
+        where TResource : IResource
+    {
+        private readonly IResourceBuilder<TResource> resourceBuilder;
+        private readonly IHealthChecksBuilder healthChecksBuilder;
+
+        internal ResourceHealthChecksBuilder(IResourceBuilder<TResource> resourceBuilder, 
+            IHealthChecksBuilder healthChecksBuilder)
+        {
+            this.resourceBuilder = resourceBuilder;
+            this.healthChecksBuilder = healthChecksBuilder;
+        }
+
+        public IServiceCollection Services => throw new NotImplementedException();
+
+        public IDistributedApplicationBuilder ApplicationBuilder => resourceBuilder.ApplicationBuilder;
+
+        public TResource Resource => resourceBuilder.Resource;
+
+        public IHealthChecksBuilder Add(HealthCheckRegistration registration)
+        {
+            healthChecksBuilder.Add(registration);
+            resourceBuilder.WithHealthCheck(registration.Name);
+            return this;
+        }
+
+        public IResourceBuilder<TResource> WithAnnotation<TAnnotation>(TAnnotation annotation,
+            ResourceAnnotationMutationBehavior behavior = ResourceAnnotationMutationBehavior.Append)
+            where TAnnotation : IResourceAnnotation
+        {
+            resourceBuilder.WithAnnotation(annotation, behavior);
+            return this;
+        }
+    }
+}

--- a/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/HealthChecksExtensions.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/HealthChecksExtensions.cs
@@ -8,11 +8,8 @@ public static class HealthChecksExtensions
 {
     public static ResourceHealthChecksBuilder<TResource> WithLocalHealthChecks<TResource>(this
         IResourceBuilder<TResource> resourceBuilder)
-        where TResource : IResource
-    {
-        return new(resourceBuilder, resourceBuilder.ApplicationBuilder.Services.AddHealthChecks());
-
-    }
+        where TResource : IResource => 
+        new(resourceBuilder, resourceBuilder.ApplicationBuilder.Services.AddHealthChecks());
 
     public class ResourceHealthChecksBuilder<TResource> : IResourceBuilder<TResource>, IHealthChecksBuilder
         where TResource : IResource

--- a/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/HealthChecksExtensions.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/HealthChecksExtensions.cs
@@ -24,7 +24,7 @@ public static class HealthChecksExtensions
             this.healthChecksBuilder = healthChecksBuilder;
         }
 
-        public IServiceCollection Services => throw new NotImplementedException();
+        public IServiceCollection Services => healthChecksBuilder.Services;
 
         public IDistributedApplicationBuilder ApplicationBuilder => resourceBuilder.ApplicationBuilder;
 

--- a/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/WaitForOutputExtensions.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/WaitForOutputExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using Aspire.Hosting.ApplicationModel;
-using C3D.Extensions.Aspire.OutputWatcher;
+using C3D.Extensions.Aspire.WaitForOutput;
 using C3D.Extensions.Aspire.OutputWatcher.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.RegularExpressions;

--- a/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/WaitForOutputExtensions.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/Extensions/WaitForOutputExtensions.cs
@@ -1,0 +1,56 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using C3D.Extensions.Aspire.OutputWatcher;
+using C3D.Extensions.Aspire.OutputWatcher.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.RegularExpressions;
+
+namespace Aspire.Hosting;
+
+public static class WaitForOutputExtensions
+{
+    public static IResourceBuilder<TResource> WaitForOutput<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        IResourceBuilder<IResource> dependency,
+        string match,
+        StringComparison comparer = StringComparison.InvariantCulture,
+        bool isSecret = false,
+        string? key = null)
+        where TResource : IResourceWithWaitSupport =>
+            dependency
+                .WithOutputWatcher(match, comparer, isSecret, key)
+                .WaitForOutput(resourceBuilder);
+
+    public static IResourceBuilder<TResource> WaitForOutput<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        IResourceBuilder<IResource> dependency,
+        Regex matcher,
+        bool isSecret = false,
+        string? key = null)
+        where TResource : IResourceWithWaitSupport =>
+            dependency.WithOutputWatcher(matcher, isSecret, key)
+                .WaitForOutput(resourceBuilder);
+
+    public static IResourceBuilder<TResource> WaitForOutput<TResource>(this
+        IResourceBuilder<TResource> resourceBuilder,
+        IResourceBuilder<IResource> dependency,
+        Func<string, bool> predicate,
+        bool isSecret = false,
+        string? key = null)
+        where TResource : IResourceWithWaitSupport => 
+            dependency.WithOutputWatcher(predicate, isSecret, key)
+                .WaitForOutput(resourceBuilder);
+
+    private static IResourceBuilder<TResource> WaitForOutput<TResource, TAnnotation>(
+        this OutputWatcherExtensions.OutputWatcherBuilder<IResource, TAnnotation> builder,
+        IResourceBuilder<TResource> resourceBuilder)
+        where TResource : IResourceWithWaitSupport
+        where TAnnotation : OutputWatcherAnnotationBase
+    {
+        var key = builder.Key;
+        builder
+            .WithLocalHealthChecks()
+            .AddTypeActivatedCheck<WaitForOutputHealthCheck>(key, builder.Resource);
+
+        return resourceBuilder.WaitFor(builder.ResourceBuilder);
+    }
+}

--- a/src/C3D/Extensions/Aspire/WaitForOutput/README.md
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/README.md
@@ -1,0 +1,30 @@
+# C3D.Extensions.Aspire.WaitForOutput
+
+This is a simple utility that waits for a specific string to appear in the console output of a process before
+starting the next process when using Aspire. 
+
+It is useful for integration tests where you want to wait for a specific string to appear in the console output of a process before proceeding.
+
+## Usage
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var sql = builder.AddSqlServer("sql");
+var sqldb = sql.AddDatabase("sqldb");
+
+// Example of waiting for a console app to output a specific message
+// This could be an Executable of some sort - such as Node, Python, etc.
+// We wait for some pre-requisite to be ready, then we wait for the console app to output a specific message
+var console = builder.AddProject<Projects.WaitForConsole_ConsoleApp>("consoleapp")
+    .WithReference(sqldb, "sqldb")
+    .WaitFor(sqldb);
+
+// webapp won't start until console has output the message "Ready Now..."
+// Note that 'console' does not have to exit, it just has to output the message
+builder.AddProject<Projects.WaitForConsole_WebApp>("webapp")
+    .WithReference(sqldb, "sqldb")
+    .WaitFor(sqldb)
+    .WaitForOutput(console, m => m == "Ready Now...");
+
+builder.Build().Run();
+```

--- a/src/C3D/Extensions/Aspire/WaitForOutput/WaitForOutputHealthCheck.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/WaitForOutputHealthCheck.cs
@@ -3,7 +3,7 @@ using C3D.Extensions.Aspire.OutputWatcher.Annotations;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
-namespace C3D.Extensions.Aspire.OutputWatcher;
+namespace C3D.Extensions.Aspire.WaitForOutput;
 
 public class WaitForOutputHealthCheck : IHealthCheck
 {

--- a/src/C3D/Extensions/Aspire/WaitForOutput/WaitForOutputHealthCheck.cs
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/WaitForOutputHealthCheck.cs
@@ -1,0 +1,31 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using C3D.Extensions.Aspire.OutputWatcher.Annotations;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace C3D.Extensions.Aspire.OutputWatcher;
+
+public class WaitForOutputHealthCheck : IHealthCheck
+{
+    private readonly IResource resource;
+    private readonly ILogger<WaitForOutputHealthCheck> logger;
+
+    public WaitForOutputHealthCheck(IResource resource, ILogger<WaitForOutputHealthCheck> logger)
+    {
+        this.resource = resource;
+        this.logger = logger;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        logger.LogDebug("Checking health for {Resource}", resource.Name);
+        if (resource.TryGetLastAnnotation<OutputWatcherAnnotation>(out var annotation))
+        {
+            return Task.FromResult(
+                annotation.Message is not null
+                    ? HealthCheckResult.Healthy(annotation.Message)
+                    : HealthCheckResult.Unhealthy());
+        }
+        return Task.FromResult(HealthCheckResult.Unhealthy("No annotation found!"));
+    }
+}

--- a/src/C3D/Extensions/Aspire/WaitForOutput/version.json
+++ b/src/C3D/Extensions/Aspire/WaitForOutput/version.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.3.37/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.1",
+  "pathFilters": [
+    ".",
+    "../Directory.Build.props",
+    "../Directory.Build.targets",
+    "../OutputWatcher"
+  ],
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$", // we release out of main
+    "^refs/heads/rel/v\\d+\\.\\d+" // we also release tags starting with rel/N.N
+  ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
+  "buildNumberOffset": 0
+}

--- a/src/C3D/Extensions/HostingExtensions.Shared/C3D.Extensions.HostingExtensions.Shared.shproj
+++ b/src/C3D/Extensions/HostingExtensions.Shared/C3D.Extensions.HostingExtensions.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>db4c7646-4434-4511-9e15-4019fef2d975</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="HostingExtensions.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/C3D/Extensions/HostingExtensions.Shared/HostingExtensions.Shared.projitems
+++ b/src/C3D/Extensions/HostingExtensions.Shared/HostingExtensions.Shared.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>db4c7646-4434-4511-9e15-4019fef2d975</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>HostingExtensions.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ServiceCollectionExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/C3D/Extensions/HostingExtensions.Shared/ServiceCollectionExtensions.cs
+++ b/src/C3D/Extensions/HostingExtensions.Shared/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+internal static class ServiceCollectionExtensions
+{
+    internal static IServiceCollection InsertHostedService<TService>(this IServiceCollection services, int index = 0)
+        where TService : class, IHostedService
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index, nameof(index));
+
+        var hostedServices = services.Where(s =>
+            s.ServiceType == typeof(IHostedService) &&
+            s.ServiceKey is null &&
+            s.ImplementationType != typeof(TService)).ToList();
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, hostedServices.Count, nameof(index));
+
+        hostedServices.Insert(index, ServiceDescriptor.Singleton<IHostedService, TService>());
+
+        return services
+            .RemoveAll<IHostedService>()   // remove all hosted services
+            .Add(hostedServices);          // re-add the hosted services with the inserted service
+    }
+}


### PR DESCRIPTION
#### PR Classification
New feature to introduce output watching capabilities in the Aspire framework.

#### PR Summary
This pull request adds functionality for monitoring console output, allowing applications to wait for specific messages before proceeding. 

#### New Packages
- C3D.Extensions.Aspire.OutputWatcher
- C3D.Extensions.Aspire.WaitForOutput

These are refined from the proof-of-concept implementation in https://github.com/CZEMacLeod/AspireWaitForConsoleOutput

