### PR TITLE
Update IISExpress package to use C3D.Extensions.Networking.PortAllocator

### DIFF
--- a/C3D.Extensions.Aspire.sln
+++ b/C3D.Extensions.Aspire.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{E1FFCD98
 		build\DetectPackages.ps1 = build\DetectPackages.ps1
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		.github\workflows\dotnet-msbuild-vstest.yml = .github\workflows\dotnet-msbuild-vstest.yml
 		global.json = global.json
 		build\ImportCert.ps1 = build\ImportCert.ps1
 		LICENSE.txt = LICENSE.txt
@@ -119,6 +120,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OutputWatcherTestProject", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C3D.Extensions.Aspire.SystemWebAdapters", "src\C3D\Extensions\Aspire\SystemWebAdapters\C3D.Extensions.Aspire.SystemWebAdapters.csproj", "{213BA945-410C-4726-B764-BF043E08ACA3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C3D.Extensions.Aspire.PortAllocator", "src\C3D\Extensions\Aspire\PortAllocator\C3D.Extensions.Aspire.PortAllocator.csproj", "{943FDA5D-9D54-414D-AAB5-76CC21F36D22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -217,6 +220,10 @@ Global
 		{213BA945-410C-4726-B764-BF043E08ACA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{213BA945-410C-4726-B764-BF043E08ACA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{213BA945-410C-4726-B764-BF043E08ACA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{943FDA5D-9D54-414D-AAB5-76CC21F36D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{943FDA5D-9D54-414D-AAB5-76CC21F36D22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{943FDA5D-9D54-414D-AAB5-76CC21F36D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{943FDA5D-9D54-414D-AAB5-76CC21F36D22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -256,6 +263,7 @@ Global
 		{41C173BA-2164-4764-B195-C815E37F36F7} = {D099C3D1-6952-4B8D-B7D9-4D623C1D6B26}
 		{13C2606F-B44D-4127-AD96-908F152E124B} = {8AFDAAF4-2682-43BB-B576-24B96DFDEF49}
 		{213BA945-410C-4726-B764-BF043E08ACA3} = {D5AA99D3-6A86-4816-8C06-41207B980DBD}
+		{943FDA5D-9D54-414D-AAB5-76CC21F36D22} = {D5AA99D3-6A86-4816-8C06-41207B980DBD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7A2C1EF4-C8A0-49A5-8198-0BFBDFE2EE42}

--- a/src/C3D/Extensions/Aspire/IISExpress/C3D.Extensions.Aspire.IISExpress.csproj
+++ b/src/C3D/Extensions/Aspire/IISExpress/C3D.Extensions.Aspire.IISExpress.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
+    <PackageReference Include="C3D.Extensions.Networking.PortAllocator" Version="0.1.19" />
     <ProjectReference Include="..\VisualStudioDebug\C3D.Extensions.Aspire.VisualStudioDebug.csproj" />
     <None Include="build\*.*" Pack="true" PackagePath="build\%(Filename)%(Extension)" Visible="true" />
   </ItemGroup>

--- a/src/C3D/Extensions/Aspire/PortAllocator/C3D.Extensions.Aspire.PortAllocator.csproj
+++ b/src/C3D/Extensions/Aspire/PortAllocator/C3D.Extensions.Aspire.PortAllocator.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>C3D.Extensions.Aspire</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
+    <PackageReference Include="C3D.Extensions.Networking.PortAllocator" Version="0.1.19" />
+  </ItemGroup>
+</Project>

--- a/src/C3D/Extensions/Aspire/PortAllocator/Extensions/.editorconfig
+++ b/src/C3D/Extensions/Aspire/PortAllocator/Extensions/.editorconfig
@@ -1,0 +1,8 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = false
+
+# C# files
+[*.cs]
+
+dotnet_style_namespace_match_folder = false
+dotnet_diagnostic.IDE0130.severity = silent

--- a/src/C3D/Extensions/Aspire/PortAllocator/Extensions/PortAllocatorExtensions.cs
+++ b/src/C3D/Extensions/Aspire/PortAllocator/Extensions/PortAllocatorExtensions.cs
@@ -1,0 +1,38 @@
+﻿using Aspire.Hosting.ApplicationModel;
+using C3D.Extensions.Aspire;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static class PortAllocatorExtensions
+{
+    /// <summary>
+    /// Add an IPortAllocator service based on actually free host ports
+    /// </summary>
+    /// <param name="services">An IServiceCollection</param>
+    /// <param name="minPort">The minimum port number to allocate (Defaults to 8000)</param>
+    /// <returns>The IServiceCollection</returns>
+    public static IServiceCollection AddHostPortAllocator(this IServiceCollection services, int minPort = 8000)
+    {
+        services.TryAddSingleton<C3D.Extensions.Networking.PortAllocator>();
+        services.AddSingleton<IPortAllocator>(sp => ActivatorUtilities.CreateInstance<HostPortAllocator>(sp, minPort));
+        return services;
+    }
+
+    /// <summary>
+    /// Add an IPortAllocator service based on actually free host ports with a key.
+    /// </summary>
+    /// <param name="services">An IServiceCollection</param>
+    /// <param name="key">The key to use when getting the keyed service</param>
+    /// <param name="minPort">The minimum port number to allocate (Defaults to 8000)</param>
+    /// <returns>The IServiceCollection</returns>
+    /// <remarks>The actual port allocator service is shared across all instances. The key only affects the min port number allocated.</remarks>
+    public static IServiceCollection AddKeyedHostPortAllocator(this IServiceCollection services, object key, int minPort = 8000)
+    {
+        services.TryAddSingleton<C3D.Extensions.Networking.PortAllocator>();
+        services.AddKeyedSingleton<IPortAllocator>(key, (sp, _) => ActivatorUtilities.CreateInstance<HostPortAllocator>(sp, minPort));
+        return services;
+    }
+
+}

--- a/src/C3D/Extensions/Aspire/PortAllocator/HostPortAllocator.cs
+++ b/src/C3D/Extensions/Aspire/PortAllocator/HostPortAllocator.cs
@@ -1,0 +1,17 @@
+﻿namespace C3D.Extensions.Aspire;
+
+public class HostPortAllocator : global::Aspire.Hosting.ApplicationModel.IPortAllocator
+{
+    private readonly Networking.PortAllocator portAllocator;
+    private readonly int startPort;
+
+    public HostPortAllocator(C3D.Extensions.Networking.PortAllocator portAllocator, int startPort = 8000)
+    {
+        this.portAllocator = portAllocator;
+        this.startPort = startPort;
+    }
+
+    public void AddUsedPort(int port) => portAllocator.MarkPortAsUsed(port);
+
+    public int AllocatePort() => portAllocator.GetRandomFreePort(startPort);
+}

--- a/src/C3D/Extensions/Aspire/PortAllocator/README.md
+++ b/src/C3D/Extensions/Aspire/PortAllocator/README.md
@@ -1,0 +1,9 @@
+# C3D.Extensions.Aspire.PortAllocator
+
+This uses the `C3D.Extensions.Networking.PortAllocator` package to implement an aspire compatible `IPortAllocator`.
+This version has a global list of allocated ports, and will scan the host system to check for any allocated port before starting.
+It is useful to ensure that if you are allocating custom/random ports for services while testing, that you don't break because there is something else using that port.
+
+It can be useful in integration testing to ensure that each test stack uses different ports so the tests don't conflict with one another.
+
+Please see [C3D.Extensions.Networking.PortAllocator](https://github.com/CZEMacLeod/C3D.Extensions.Networking.PortAllocator) for more information.

--- a/src/C3D/Extensions/Aspire/PortAllocator/version.json
+++ b/src/C3D/Extensions/Aspire/PortAllocator/version.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.3.37/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.1",
+  "pathFilters": [
+    ".",
+    "../Directory.Build.props",
+    "../Directory.Build.targets",
+    "../OutputWatcher",
+    "../../Directory.Build.props",
+    "../../Directory.Build.targets",
+    "../../HostingExtensions.Shared"
+  ],
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$", // we release out of main
+    "^refs/heads/rel/v\\d+\\.\\d+" // we also release tags starting with rel/N.N
+  ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
+  "buildNumberOffset": 0
+}

--- a/tests/SWATestProject/Fixtures/NetworkingFixture.cs
+++ b/tests/SWATestProject/Fixtures/NetworkingFixture.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SWATestProject.Fixtures;
+
+public class NetworkingFixture
+{
+    public NetworkingFixture()
+    {
+        this.PortAllocator = new C3D.Extensions.Networking.PortAllocator();
+    }
+
+    public C3D.Extensions.Networking.PortAllocator PortAllocator { get; }
+}

--- a/tests/SWATestProject/SWATestProject.csproj
+++ b/tests/SWATestProject/SWATestProject.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="13.1.0" />
+    <PackageReference Include="C3D.Extensions.Networking.PortAllocator" Version="0.1.19" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Replaces internal implementation of this code.
Also includes `IPortAllocator` proxy implementation that can be used by Aspire.